### PR TITLE
[JSC] move function wrapping logic to a new Function type -- WIP

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1093,6 +1093,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSPromiseConstructor.h
     runtime/JSPropertyNameEnumerator.h
     runtime/JSProxy.h
+    runtime/JSRemoteFunction.h
     runtime/JSRunLoopTimer.h
     runtime/JSScope.h
     runtime/JSScriptFetchParameters.h

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -907,6 +907,7 @@ runtime/JSPromiseConstructor.cpp
 runtime/JSPromisePrototype.cpp
 runtime/JSPropertyNameEnumerator.cpp
 runtime/JSProxy.cpp
+runtime/JSRemoteFunction.cpp
 runtime/JSRunLoopTimer.cpp
 runtime/JSScope.cpp
 runtime/JSScriptFetcher.cpp

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -188,6 +188,8 @@ namespace JSC {
     macro(outOfLineReactionCounts) \
     macro(emptyPropertyNameEnumerator) \
     macro(sentinelString) \
+    macro(createRemoteFunction) \
+    macro(isRemoteFunction) \
 
 
 namespace Symbols {

--- a/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
+++ b/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
@@ -32,28 +32,7 @@ function wrap(fromShadowRealm, shadowRealm, target)
     "use strict";
 
     if (@isCallable(target)) {
-        var wrapped = function(/* args... */) {
-            var length = arguments.length;
-            var wrappedArgs = @newArrayWithSize(length);
-            for (var index = 0; index < length; ++index)
-                // Note that for arguments, we flip `fromShadowRealm` since to
-                // wrap a function from realm A to work in realm B, we need to
-                // wrap the arguments (from realm B) to work in realm A before
-                // calling the wrapped function
-                @putByValDirect(wrappedArgs, index, @wrap(!fromShadowRealm, shadowRealm, arguments[index]));
-
-            var result = target.@apply(@undefined, wrappedArgs);
-            return @wrap(fromShadowRealm, shadowRealm, result);
-        };
-        delete wrapped['name'];
-        delete wrapped['length'];
-
-        // Because this function (wrap) will run with the incubating realm
-        // active, we only need to fix the prototype on `wrapped` if we are
-        // moving the function from the incubating realm to the shadow realm
-        if (!fromShadowRealm)
-            @moveFunctionToRealm(wrapped, shadowRealm);
-        return wrapped;
+        target = @createRemoteFunction(target, fromShadowRealm ? null : shadowRealm);
     } else if (@isObject(target)) {
         @throwTypeError("value passing between realms must be callable or primitive");
     }

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -116,6 +116,8 @@ class JSGlobalObject;
     v(createPrivateSymbol, nullptr) \
     v(emptyPropertyNameEnumerator, nullptr) \
     v(sentinelString, nullptr) \
+    v(createRemoteFunction, nullptr) \
+    v(isRemoteFunction, nullptr) \
 
 
 #define DECLARE_LINK_TIME_CONSTANT(name, code) name,

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -133,8 +133,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetWrappedValue, EncodedJSValue, (JSFunction* 
     }
 
     if (value.isCallable(vm)) {
-        JSCallee* targetCallee = jsCast<JSCallee*>(value.asCell());
-        ASSERT(targetCallee->globalObject() != targetGlobalObject);
+        JSFunction* targetCallee = static_cast<JSFunction*>(value.asCell());
         return JSValue::encode(JSRemoteFunction::create(vm, targetGlobalObject, targetCallee));
     }
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp.autosave
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp.autosave
@@ -116,29 +116,22 @@ JSC_DEFINE_JIT_OPERATION(operationThrowStackOverflowErrorFromThunk, void, (JSGlo
     ASSERT(vm.targetMachinePCForThrow);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationGetWrappedValue, EncodedJSValue, (JSFunction* callee, EncodedJSValue encodedValue))
+JSC_DEFINE_JIT_OPERATION(operationGetWrappedValue, EncodedJSValue, (JSGlobalObject* targetGlobalObject, EncodedJSValue encodedValue))
 {
-    ASSERT(isRemoteFunction(callee));
-    JSGlobalObject* globalObject = callee->globalObject();
-    VM& vm = globalObject->vm();
-
+    VM& vm = targetGlobalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-
-    JSGlobalObject* targetGlobalObject = jsCast<JSRemoteFunction*>(callee)->targetFunction()->globalObject();
-
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = JSValue::decode(encodedValue);
-    if (!value.isObject()) {
-        return encodedValue;
-    }
+    if (value.isPrimitive())
+        RELEASE_AND_RETURN(scope, encodedValue);
 
     if (value.isCallable(vm)) {
         JSCallee* targetCallee = jsCast<JSCallee*>(value.asCell());
-        ASSERT(targetCallee->globalObject() != targetGlobalObject);
+        ASSERT(targetCallee->structure()->globalObject() != targetGlobalObject);
+
         return JSValue::encode(JSRemoteFunction::create(vm, targetGlobalObject, targetCallee));
     }
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
     throwTypeError(targetGlobalObject, scope, "value passing between realms must be callable or primitive");
     return encodedJSValue();
 }

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -155,6 +155,7 @@ JSC_DECLARE_JIT_OPERATION(operationLookupExceptionHandlerFromCallerFrame, void, 
 JSC_DECLARE_JIT_OPERATION(operationVMHandleException, void, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationThrowStackOverflowErrorFromThunk, void, (JSGlobalObject*));
 JSC_DECLARE_JIT_OPERATION(operationThrowIteratorResultIsNotObject, void, (JSGlobalObject*));
+JSC_DECLARE_JIT_OPERATION(operationGetWrappedValue, EncodedJSValue, (JSFunction*, EncodedJSValue));
 
 JSC_DECLARE_JIT_OPERATION(operationThrowStackOverflowError, void, (CodeBlock*));
 JSC_DECLARE_JIT_OPERATION(operationCallArityCheck, int32_t, (JSGlobalObject*));

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -1540,6 +1540,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM& vm)
     jit.ret();
 
     checkException.link(&jit);
+    jit.print("EXCEPTION HANDLED\n");
     jit.copyCalleeSavesToEntryFrameCalleeSavesBuffer(vm.topEntryFrame);
     jit.jumpToExceptionHandler(vm);
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -79,6 +79,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> truncThunkGenerator(VM&);
 
 MacroAssemblerCodeRef<JITThunkPtrTag> boundFunctionCallGenerator(VM&);
 
+MacroAssemblerCodeRef<JITThunkPtrTag> remoteFunctionCallGenerator(VM&);
+
 #if ENABLE(EXTRA_CTI_THUNKS)
 MacroAssemblerCodeRef<JITThunkPtrTag> checkExceptionGenerator(VM&);
 #endif

--- a/Source/JavaScriptCore/runtime/Intrinsic.cpp
+++ b/Source/JavaScriptCore/runtime/Intrinsic.cpp
@@ -205,6 +205,8 @@ const char* intrinsicName(Intrinsic intrinsic)
         return "IsTypedArrayViewIntrinsic";
     case BoundFunctionCallIntrinsic:
         return "BoundFunctionCallIntrinsic";
+    case RemoteFunctionCallIntrinsic:
+        return "RemoteFunctionCallIntrinsic";
     case JSMapGetIntrinsic:
         return "JSMapGetIntrinsic";
     case JSMapHasIntrinsic:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -118,6 +118,7 @@ enum Intrinsic : uint8_t {
     TypedArrayEntriesIntrinsic,
     IsTypedArrayViewIntrinsic,
     BoundFunctionCallIntrinsic,
+    RemoteFunctionCallIntrinsic,
     JSMapGetIntrinsic,
     JSMapHasIntrinsic,
     JSMapSetIntrinsic,

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -99,6 +99,7 @@ struct JSTypeRange {
     macro(JSSymbolTableObject, JSType::GlobalObjectType, JSType::ModuleEnvironmentType) \
     macro(JSScope, JSType::GlobalObjectType, JSType::WithScopeType) \
     macro(StringObject, JSType::StringObjectType, JSType::DerivedStringObjectType) \
+    macro(ShadowRealmObject, JSType::ShadowRealmType, JSType::ShadowRealmType) \
 
 
 // Forward declare the classes because they may not already exist.

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -150,6 +150,7 @@ public:
     bool isBuiltinFunction() const;
     JS_EXPORT_PRIVATE bool isHostFunctionNonInline() const;
     bool isClassConstructorFunction() const;
+    bool isRemoteFunction() const;
 
     void setFunctionName(JSGlobalObject*, JSValue name);
 

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -27,6 +27,7 @@
 
 #include "FunctionExecutable.h"
 #include "JSBoundFunction.h"
+#include "JSRemoteFunction.h"
 #include "JSFunction.h"
 #include "NativeExecutable.h"
 
@@ -78,6 +79,11 @@ inline bool JSFunction::isClassConstructorFunction() const
     return !isHostFunction() && jsExecutable()->isClassConstructorFunction();
 }
 
+inline bool JSFunction::isRemoteFunction() const
+{
+    return static_cast<bool>(jsDynamicCast<const JSRemoteFunction*>(globalObject()->vm(), this));
+}
+
 inline TaggedNativeFunction JSFunction::nativeFunction()
 {
     ASSERT(isHostFunctionNonInline());
@@ -96,6 +102,14 @@ inline bool isHostFunction(JSValue value, TaggedNativeFunction nativeFunction)
     if (!function || !function->isHostFunction())
         return false;
     return function->nativeFunction() == nativeFunction;
+}
+
+inline bool isRemoteFunction(JSValue value)
+{
+    JSFunction* function = jsCast<JSFunction*>(getJSFunction(value));
+    if (!function)
+        return false;
+    return function->isRemoteFunction();
 }
 
 inline bool JSFunction::hasReifiedLength() const

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -140,6 +140,7 @@
 #include "JSPromise.h"
 #include "JSPromiseConstructor.h"
 #include "JSPromisePrototype.h"
+#include "JSRemoteFunction.h"
 #include "JSSet.h"
 #include "JSSetIterator.h"
 #include "JSStringIterator.h"
@@ -768,6 +769,10 @@ void JSGlobalObject::init(VM& vm)
     m_nativeStdFunctionStructure.initLater(
         [] (const Initializer<Structure>& init) {
             init.set(JSNativeStdFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
+        });
+    m_remoteFunctionStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(JSRemoteFunction::createStructure(init.vm, init.owner, init.owner->m_functionPrototype.get()));
         });
     JSFunction* callFunction = nullptr;
     JSFunction* applyFunction = nullptr;
@@ -1527,6 +1532,14 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), createPrivateSymbol));
         });
 
+    // ShadowRealms
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::createRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), createRemoteFunction));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isRemoteFunction)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, String(), isRemoteFunction));
+        });
+
 #if ENABLE(WEBASSEMBLY)
     // WebAssembly Streaming API
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::webAssemblyCompileStreamingInternal)].initLater([] (const Initializer<JSCell>& init) {
@@ -2255,6 +2268,7 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_customSetterFunctionStructure.visit(visitor);
     thisObject->m_boundFunctionStructure.visit(visitor);
     thisObject->m_nativeStdFunctionStructure.visit(visitor);
+    thisObject->m_remoteFunctionStructure.visit(visitor);
     visitor.append(thisObject->m_shadowRealmObjectStructure);
     visitor.append(thisObject->m_regExpStructure);
     visitor.append(thisObject->m_generatorFunctionStructure);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -418,6 +418,7 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_customGetterFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_customSetterFunctionStructure;
     LazyProperty<JSGlobalObject, Structure> m_nativeStdFunctionStructure;
+    LazyProperty<JSGlobalObject, Structure> m_remoteFunctionStructure;
     PropertyOffset m_functionNameOffset;
     WriteBarrier<Structure> m_shadowRealmObjectStructure;
     WriteBarrier<Structure> m_regExpStructure;
@@ -861,6 +862,7 @@ public:
     Structure* regExpMatchesArrayStructure() const { return m_regExpMatchesArrayStructure.get(); }
     Structure* regExpMatchesArrayWithIndicesStructure() const { return m_regExpMatchesArrayWithIndicesStructure.get(); }
     Structure* regExpMatchesIndicesArrayStructure() const { return m_regExpMatchesIndicesArrayStructure.get(); }
+    Structure* remoteFunctionStructure() const { return m_remoteFunctionStructure.get(this); }
     Structure* moduleRecordStructure() const { return m_moduleRecordStructure.get(this); }
     Structure* moduleNamespaceObjectStructure() const { return m_moduleNamespaceObjectStructure.get(this); }
     Structure* proxyObjectStructure() const { return m_proxyObjectStructure.get(this); }

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2021 Igalia S.L.
+ * Author: Caitlin Potter <caitp@igalia.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSRemoteFunction.h"
+
+#include "ExecutableBaseInlines.h"
+#include "JSCInlines.h"
+#include "ShadowRealmObject.h"
+
+#include <wtf/Assertions.h>
+
+namespace JSC {
+
+const ClassInfo JSRemoteFunction::s_info = { "Function", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSRemoteFunction) };
+
+JSRemoteFunction::JSRemoteFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSCallee* targetFunction)
+    : Base(vm, executable, globalObject, structure)
+    , m_targetFunction(vm, this, targetFunction)
+{
+}
+
+JSValue wrapValue(JSGlobalObject* globalObject, JSGlobalObject* targetGlobalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+
+    if (value.isPrimitive())
+        return value;
+
+    if (value.isCallable(vm)) {
+        JSCallee* targetCallee = jsCast<JSCallee*>(value.asCell());
+        ASSERT(targetCallee->structure()->globalObject() != targetGlobalObject);
+
+        return JSValue(JSRemoteFunction::create(vm, targetGlobalObject, targetCallee));
+    }
+
+    return JSValue();
+}
+
+static inline JSValue wrapArgument(JSGlobalObject* globalObject, JSGlobalObject* targetGlobalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue result = wrapValue(globalObject, targetGlobalObject, value);
+    if (result.isEmpty())
+        throwVMError(globalObject, scope, createTypeError(globalObject, "value passing between realms must be callable or primitive"));
+    return result;
+}
+
+static inline JSValue wraprReturnValue(JSGlobalObject* globalObject, JSGlobalObject* targetGlobalObject, JSValue value)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue result = wrapValue(globalObject, targetGlobalObject, value);
+    if (result.isEmpty())
+        throwVMError(globalObject, scope, createTypeError(globalObject, "value passing between realms must be callable or primitive"));
+    return result;
+}
+
+JSC_DEFINE_HOST_FUNCTION(remoteJSFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
+    JSFunction* targetFunction = jsCast<JSFunction*>(remoteFunction->targetFunction());
+    JSGlobalObject* targetGlobalObject = targetFunction->structure()->globalObject();
+
+    RELEASE_ASSERT(targetGlobalObject != globalObject);
+
+    MarkedArgumentBuffer args;
+    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+        JSValue wrappedValue = wrapArgument(globalObject, targetGlobalObject, callFrame->uncheckedArgument(i));
+        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        args.append(wrappedValue);
+    }
+    if (UNLIKELY(args.hasOverflowed())) {
+        throwOutOfMemoryError(globalObject, scope);
+        return encodedJSValue();
+    }
+    ExecutableBase* executable = targetFunction->executable();
+    if (executable->hasJITCodeForCall()) {
+        // Force the executable to cache its arity entrypoint.
+        executable->entrypointFor(CodeForCall, MustCheckArity);
+    }
+
+    auto callData = getCallData(vm, targetFunction);
+    ASSERT(callData.type != CallData::Type::None);
+    auto result = call(targetGlobalObject, targetFunction, callData, jsUndefined(), args);
+
+    // Hide exceptions from calling realm
+    if (scope.exception()) {
+        scope.clearException();
+        throwTypeError(globalObject, scope);
+        return encodedJSValue();
+    }
+
+    auto wrappedResult = wraprReturnValue(globalObject, globalObject, result);
+    RELEASE_AND_RETURN(scope, JSValue::encode(wrappedResult));
+}
+
+JSC_DEFINE_HOST_FUNCTION(remoteFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
+    JSObject* targetFunction = remoteFunction->targetFunction();
+    JSGlobalObject* targetGlobalObject = targetFunction->structure()->globalObject();
+
+    RELEASE_ASSERT(targetGlobalObject != globalObject);
+
+    MarkedArgumentBuffer args;
+    for (unsigned i = 0; i < callFrame->argumentCount(); ++i) {
+        JSValue wrappedValue = wrapValue(globalObject, targetGlobalObject, callFrame->uncheckedArgument(i));
+        args.append(wrappedValue);
+    }
+    if (UNLIKELY(args.hasOverflowed())) {
+        throwOutOfMemoryError(globalObject, scope);
+        return encodedJSValue();
+    }
+
+    auto callData = getCallData(vm, targetFunction);
+    ASSERT(callData.type != CallData::Type::None);
+    auto result = call(targetGlobalObject, targetFunction, callData, jsUndefined(), args);
+
+    // Hide exceptions from calling realm
+    if (scope.exception()) {
+        scope.clearException();
+        throwTypeError(globalObject, scope);
+        return encodedJSValue();
+    }
+
+    auto wrappedResult = wrapValue(targetGlobalObject, globalObject, result);
+    RELEASE_AND_RETURN(scope, JSValue::encode(wrappedResult));
+}
+
+JSC_DEFINE_HOST_FUNCTION(remoteFunctionConstruct, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    throwTypeError(globalObject, scope);
+    return encodedJSValue();
+}
+
+JSC_DEFINE_HOST_FUNCTION(isRemoteFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    return JSValue::encode(JSValue(static_cast<bool>(jsDynamicCast<JSRemoteFunction*>(globalObject->vm(), callFrame->uncheckedArgument(0)))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(callFrame->argumentCount() == 2);
+    JSCallee* targetFunction = jsCast<JSCallee*>(callFrame->uncheckedArgument(0));
+    JSGlobalObject* destinationGlobalObject = globalObject;
+    if (!callFrame->uncheckedArgument(1).isUndefinedOrNull()) {
+        if (auto shadowRealm = jsDynamicCast<ShadowRealmObject*>(vm, callFrame->uncheckedArgument(1))) {
+            dataLog("using ShadowRealm's globalObject\n");
+            destinationGlobalObject = shadowRealm->globalObject();
+        } else {
+            dataLog("using global object\n");
+            destinationGlobalObject = jsCast<JSGlobalObject*>(callFrame->uncheckedArgument(1));
+        }
+    }
+
+    ASSERT(destinationGlobalObject != targetFunction->globalObject());
+
+    auto result = JSRemoteFunction::create(vm, destinationGlobalObject, targetFunction);
+    RELEASE_AND_RETURN(scope, JSValue::encode(result));
+}
+
+inline Structure* getRemoteFunctionStructure(JSGlobalObject* globalObject)
+{
+    // FIXME: implement globalObject-aware structure caching
+    return globalObject->remoteFunctionStructure();
+}
+
+JSRemoteFunction* JSRemoteFunction::create(VM& vm, JSGlobalObject* globalObject, JSCallee* targetFunction)
+{
+    ASSERT(globalObject != targetFunction->structure()->globalObject());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    bool isJSFunction = getJSFunction(targetFunction);
+    NativeExecutable* executable = vm.getRemoteFunction(isJSFunction);
+    Structure* structure = getRemoteFunctionStructure(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    JSRemoteFunction* function = new (NotNull, allocateCell<JSRemoteFunction>(vm)) JSRemoteFunction(vm, executable, globalObject, structure, targetFunction);
+
+    function->finishCreation(vm);
+    return function;
+}
+
+void JSRemoteFunction::finishCreation(VM& vm)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(vm, info()));
+}
+
+template<typename Visitor>
+void JSRemoteFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    JSRemoteFunction* thisObject = jsCast<JSRemoteFunction*>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
+    Base::visitChildren(thisObject, visitor);
+
+    visitor.append(thisObject->m_targetFunction);
+}
+
+DEFINE_VISIT_CHILDREN(JSRemoteFunction);
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -170,13 +170,10 @@ JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, Ca
     JSCallee* targetFunction = jsCast<JSCallee*>(callFrame->uncheckedArgument(0));
     JSGlobalObject* destinationGlobalObject = globalObject;
     if (!callFrame->uncheckedArgument(1).isUndefinedOrNull()) {
-        if (auto shadowRealm = jsDynamicCast<ShadowRealmObject*>(vm, callFrame->uncheckedArgument(1))) {
-            dataLog("using ShadowRealm's globalObject\n");
+        if (auto shadowRealm = jsDynamicCast<ShadowRealmObject*>(vm, callFrame->uncheckedArgument(1)))
             destinationGlobalObject = shadowRealm->globalObject();
-        } else {
-            dataLog("using global object\n");
+        else
             destinationGlobalObject = jsCast<JSGlobalObject*>(callFrame->uncheckedArgument(1));
-        }
     }
 
     ASSERT(destinationGlobalObject != targetFunction->globalObject());

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -156,15 +156,6 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCall, (JSGlobalObject* globalObject, Call
     RELEASE_AND_RETURN(scope, JSValue::encode(wrappedResult));
 }
 
-JSC_DEFINE_HOST_FUNCTION(remoteFunctionConstruct, (JSGlobalObject* globalObject, CallFrame* callFrame))
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    throwTypeError(globalObject, scope);
-    return encodedJSValue();
-}
-
 JSC_DEFINE_HOST_FUNCTION(isRemoteFunction, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(JSValue(static_cast<bool>(jsDynamicCast<JSRemoteFunction*>(globalObject->vm(), callFrame->uncheckedArgument(0)))));

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -82,6 +82,7 @@ static inline JSValue wraprReturnValue(JSGlobalObject* globalObject, JSGlobalObj
 
 JSC_DEFINE_HOST_FUNCTION(remoteJSFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    dataLog("remoteJSFunctionCall\n");
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
@@ -123,6 +124,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteJSFunctionCall, (JSGlobalObject* globalObject, Ca
 
 JSC_DEFINE_HOST_FUNCTION(remoteFunctionCall, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
+    dataLog("remoteFunctionCall\n");
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSRemoteFunction* remoteFunction = jsCast<JSRemoteFunction*>(callFrame->jsCallee());
@@ -170,10 +172,13 @@ JSC_DEFINE_HOST_FUNCTION(createRemoteFunction, (JSGlobalObject* globalObject, Ca
     JSCallee* targetFunction = jsCast<JSCallee*>(callFrame->uncheckedArgument(0));
     JSGlobalObject* destinationGlobalObject = globalObject;
     if (!callFrame->uncheckedArgument(1).isUndefinedOrNull()) {
+        dataLog("creating remote function for shadow realm\n");
         if (auto shadowRealm = jsDynamicCast<ShadowRealmObject*>(vm, callFrame->uncheckedArgument(1)))
             destinationGlobalObject = shadowRealm->globalObject();
         else
             destinationGlobalObject = jsCast<JSGlobalObject*>(callFrame->uncheckedArgument(1));
+    } else {
+        dataLog("creating remote function for incubator realm\n");
     }
 
     ASSERT(destinationGlobalObject != targetFunction->globalObject());

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.cpp
@@ -66,7 +66,7 @@ static inline JSValue wrapArgument(JSGlobalObject* globalObject, JSGlobalObject*
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue result = wrapValue(globalObject, targetGlobalObject, value);
     if (result.isEmpty())
-        throwVMError(globalObject, scope, createTypeError(globalObject, "value passing between realms must be callable or primitive"));
+        throwTypeError(globalObject, scope, "value passing between realms must be callable or primitive");
     return result;
 }
 
@@ -76,7 +76,7 @@ static inline JSValue wraprReturnValue(JSGlobalObject* globalObject, JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue result = wrapValue(globalObject, targetGlobalObject, value);
     if (result.isEmpty())
-        throwVMError(globalObject, scope, createTypeError(globalObject, "value passing between realms must be callable or primitive"));
+        throwTypeError(globalObject, scope, "value passing between realms must be callable or primitive");
     return result;
 }
 
@@ -113,7 +113,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteJSFunctionCall, (JSGlobalObject* globalObject, Ca
     // Hide exceptions from calling realm
     if (scope.exception()) {
         scope.clearException();
-        throwTypeError(globalObject, scope);
+        throwTypeError(globalObject, scope, "an error occurred in remote realm");
         return encodedJSValue();
     }
 
@@ -148,7 +148,7 @@ JSC_DEFINE_HOST_FUNCTION(remoteFunctionCall, (JSGlobalObject* globalObject, Call
     // Hide exceptions from calling realm
     if (scope.exception()) {
         scope.clearException();
-        throwTypeError(globalObject, scope);
+        throwTypeError(globalObject, scope, "an error occurred in remote realm");
         return encodedJSValue();
     }
 

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -34,7 +34,6 @@ namespace JSC {
 
 JSC_DECLARE_HOST_FUNCTION(remoteJSFunctionCall);
 JSC_DECLARE_HOST_FUNCTION(remoteFunctionCall);
-JSC_DECLARE_HOST_FUNCTION(remoteFunctionConstruct);
 JSC_DECLARE_HOST_FUNCTION(isRemoteFunction);
 JSC_DECLARE_HOST_FUNCTION(createRemoteFunction);
 

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -54,6 +54,7 @@ public:
     JS_EXPORT_PRIVATE static JSRemoteFunction* create(VM&, JSGlobalObject*, JSCallee* targetFunction);
 
     JSCallee* targetFunction() { return m_targetFunction.get(); }
+    JSGlobalObject* targetGlobalObject() { return targetFunction()->globalObject(); }
 
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
     {

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -51,9 +51,12 @@ public:
         return vm.remoteFunctionSpace<mode>();
     }
 
-    JS_EXPORT_PRIVATE static JSRemoteFunction* create(VM&, JSGlobalObject*, JSCallee* targetFunction);
+    JS_EXPORT_PRIVATE static JSRemoteFunction* create(VM&, JSGlobalObject*, JSCell* targetCallable);
 
-    JSCallee* targetFunction() { return m_targetFunction.get(); }
+    JSCell* target() { return m_target.get(); }
+    JSFunction* targetFunction() {
+        return static_cast<JSFunction*>(getJSFunction(target()));
+    }
     JSGlobalObject* targetGlobalObject() { return targetFunction()->globalObject(); }
 
     static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
@@ -62,17 +65,17 @@ public:
         return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info()); 
     }
     
-    static ptrdiff_t offsetOfTargetFunction() { return OBJECT_OFFSETOF(JSRemoteFunction, m_targetFunction); }
+    static ptrdiff_t offsetOfTarget() { return OBJECT_OFFSETOF(JSRemoteFunction, m_target); }
 
     DECLARE_INFO;
 
 private:
-    JSRemoteFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSCallee* targetFunction);
+    JSRemoteFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSCell* targetCallable);
 
     void finishCreation(VM&);
     DECLARE_VISIT_CHILDREN;
 
-    WriteBarrier<JSCallee> m_targetFunction;
+    WriteBarrier<JSCell> m_target;
 };
 
 }

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 Igalia S.L.
+ * Author: Caitlin Potter <caitp@igalia.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AuxiliaryBarrier.h"
+#include "JSObject.h"
+#include <wtf/TaggedArrayStoragePtr.h>
+
+namespace JSC {
+
+JSC_DECLARE_HOST_FUNCTION(remoteJSFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(remoteFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(remoteFunctionConstruct);
+JSC_DECLARE_HOST_FUNCTION(isRemoteFunction);
+JSC_DECLARE_HOST_FUNCTION(createRemoteFunction);
+
+// JSRemoteFunction creates a bridge between its native Realm and a remote one.
+// When invoked, arguments are wrapped to prevent leaking information across the realm boundary.
+// The return value and any abrupt completions are also filtered.
+class JSRemoteFunction final : public JSFunction {
+public:
+    typedef JSFunction Base;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    template<typename CellType, SubspaceAccess mode>
+    static IsoSubspace* subspaceFor(VM& vm)
+    {
+        return vm.remoteFunctionSpace<mode>();
+    }
+
+    JS_EXPORT_PRIVATE static JSRemoteFunction* create(VM&, JSGlobalObject*, JSCallee* targetFunction);
+
+    JSCallee* targetFunction() { return m_targetFunction.get(); }
+
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+    {
+        ASSERT(globalObject);
+        return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info()); 
+    }
+    
+    static ptrdiff_t offsetOfTargetFunction() { return OBJECT_OFFSETOF(JSRemoteFunction, m_targetFunction); }
+
+    DECLARE_INFO;
+
+private:
+    JSRemoteFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSCallee* targetFunction);
+
+    void finishCreation(VM&);
+    DECLARE_VISIT_CHILDREN;
+
+    WriteBarrier<JSCallee> m_targetFunction;
+};
+
+}

--- a/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ShadowRealmPrototype.cpp
@@ -116,10 +116,11 @@ JSC_DEFINE_HOST_FUNCTION(evalInRealm, (JSGlobalObject* globalObject, CallFrame* 
     RETURN_IF_EXCEPTION(scope, { });
 
     JSValue result = vm.interpreter->execute(eval, realmGlobalObject, realmGlobalObject->globalThis(), realmGlobalObject->globalScope());
-    if (UNLIKELY(scope.exception())) {
-        scope.clearException();
-        return throwVMError(globalObject, scope, createTypeError(globalObject, "Error encountered during evaluation"_s));
-    }
+    // FIXME: uncomment this, just using this to get a closer idea what's going wrong during evaluation.
+    //if (UNLIKELY(scope.exception())) {
+    //    scope.clearException();
+    //    return throwVMError(globalObject, scope, createTypeError(globalObject, "Error encountered during evaluation"_s));
+    // }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(result));
 }

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -822,6 +822,8 @@ static ThunkGenerator thunkGeneratorForIntrinsic(Intrinsic intrinsic)
         return randomThunkGenerator;
     case BoundFunctionCallIntrinsic:
         return boundFunctionCallGenerator;
+    case RemoteFunctionCallIntrinsic:
+        return remoteFunctionCallGenerator;
     default:
         return nullptr;
     }
@@ -908,8 +910,7 @@ NativeExecutable* VM::getRemoteFunction(bool isJSFunction)
             return cached;
         NativeExecutable* result = getHostFunction(
             slowCase ? remoteFunctionCall : remoteJSFunctionCall,
-            // FIXME: Add thunk generator for FastRemoteFunctionCall
-            slowCase ? NoIntrinsic : NoIntrinsic,
+            slowCase ? NoIntrinsic : RemoteFunctionCallIntrinsic,
             callHostFunctionAsConstructor, nullptr, String());
         slot = Weak<NativeExecutable>(result);
         return result;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -910,7 +910,7 @@ NativeExecutable* VM::getRemoteFunction(bool isJSFunction)
             slowCase ? remoteFunctionCall : remoteJSFunctionCall,
             // FIXME: Add thunk generator for FastRemoteFunctionCall
             slowCase ? NoIntrinsic : NoIntrinsic,
-            remoteFunctionConstruct, nullptr, String());
+            callHostFunctionAsConstructor, nullptr, String());
         slot = Weak<NativeExecutable>(result);
         return result;
     };

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -599,6 +599,7 @@ public:
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(nativeStdFunctionSpace)
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(proxyObjectSpace)
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(proxyRevokeSpace)
+    DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(remoteFunctionSpace)
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(scopedArgumentsTableSpace)
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(scriptFetchParametersSpace)
     DYNAMIC_ISO_SUBSPACE_DEFINE_MEMBER(scriptFetcherSpace)
@@ -791,6 +792,9 @@ public:
     Weak<NativeExecutable> m_slowBoundExecutable;
     Weak<NativeExecutable> m_slowCanConstructBoundExecutable;
 
+    Weak<NativeExecutable> m_fastRemoteFunctionExecutable;
+    Weak<NativeExecutable> m_slowRemoteFunctionExecutable;
+
     Ref<DeferredWorkTimer> deferredWorkTimer;
 
     JSCell* currentlyDestructingCallbackObject;
@@ -904,6 +908,7 @@ public:
     NativeExecutable* getHostFunction(NativeFunction, Intrinsic, NativeFunction constructor, const DOMJIT::Signature*, const String& name);
 
     NativeExecutable* getBoundFunction(bool isJSFunction, bool canConstruct);
+    NativeExecutable* getRemoteFunction(bool isJSFunction);
 
     MacroAssemblerCodePtr<JSEntryPtrTag> getCTIInternalFunctionTrampolineFor(CodeSpecializationKind);
     MacroAssemblerCodeRef<JSEntryPtrTag> getCTILinkCall();

--- a/test.js
+++ b/test.js
@@ -1,0 +1,49 @@
+function assertThrows(thing, kind) {
+	let error;
+	let threw = false;
+	let kindString = () => {
+		return kind.name;
+	}
+	try {
+		thing();
+	} catch (e) {
+		error = e;
+		threw = true;
+	}
+
+	if (!threw)
+		throw new Error("Expected to throw " + kindString() + ", but did not throw");
+
+	if (!(error instanceof kind))
+		throw new Error("Expected to throw " + kindString() + ", but threw " + error);
+}
+function assert(expr, message) {
+	if (!expr)
+		throw new Error(message || "Assertion failed");
+}
+print("creating ShadowRealm");
+let r = new ShadowRealm;
+
+print("test remote-calling a function which throws from outside a ShadowRealm");
+r.evaluate("globalThis.lastValue = 1;");
+if (globalThis.lastValue === 1)
+	throw new Error("ran in wrong realm");
+
+print("shadowrealm evaluate function which invokes its argument with `lastValue`");
+let f = r.evaluate("(function(f) { return f(lastValue); })");
+
+assert(!r.evaluate("!!globalThis.print"));
+let exportValue = r.evaluate("(function(name, value) { this[name] = value; })");
+print("exporting function print");
+exportValue("print", globalThis.print);
+print("testing that the export worked");
+assert(r.evaluate("!!this.print"));
+
+print("shadowrealm evaluate function which throws a TypeError");
+let thrower = r.evaluate("(function thrower() { globalThis.print('throwing \"butts\"'); /*throw new TypeError('butts');*/ })");
+
+print("test remote-calling a function which throws from outside a ShadowRealm");
+assertThrows(() => { f(thrower); }, TypeError);
+
+
+print("done!");

--- a/test2.js
+++ b/test2.js
@@ -1,0 +1,12 @@
+let r = new ShadowRealm;
+
+let exportValue = r.evaluate(`
+	(function(exportName, exportValue) {
+		globalThis[exportName] = exportValue;
+	})
+`);
+
+print("typeof globalThis.print: ", typeof globalThis.print);
+print("typeof shadowRealm globalThis.print: ", r.evaluate("typeof globalThis.print"));
+exportValue("print", globalThis.print);
+print("typeof shadowRealm globalThis.print: ", r.evaluate("typeof globalThis.print"));


### PR DESCRIPTION
In this initial patch, there is still a lot of JS-builtin machinery,
including some duplicated functionality. Additionally, JIT support
has not been incorporated yet.

Broadly, the idea is that there are custom hooks for calling a
JSRemoteFunction, which perform the wrapping functionality. This avoids
the need for allocating closures which contain the wrapping logic.

- [x] basic runtime
- [ ] JIT/DFG/FTL support
- [ ] structure caching (unnecessary since these are not constructors?)
- [ ] improved baseline perf